### PR TITLE
fix: use exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
   "name": "@minswap/sdk",
   "version": "0.2.0-beta",
   "description": "Query Minswap data and build transactions",
-  "main": "./build/index.js",
-  "module": "./build/index.es.js",
-  "types": "./build/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "import": "./build/index.es.js"
+    }
+  },
   "files": [
     "build"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,6 @@
 import dts from "rollup-plugin-dts";
 import esbuild from "rollup-plugin-esbuild";
 
-const name = require("./package.json").main.replace(/\.js$/, "");
-
 const bundle = (config) => ({
   ...config,
   input: "src/index.ts",
@@ -14,12 +12,7 @@ export default [
     plugins: [esbuild()],
     output: [
       {
-        file: `${name}.js`,
-        format: "cjs",
-        sourcemap: true,
-      },
-      {
-        file: `${name}.es.js`,
+        file: `build/index.es.js`,
         format: "es",
         sourcemap: true,
       },
@@ -28,7 +21,7 @@ export default [
   bundle({
     plugins: [dts()],
     output: {
-      file: `${name}.d.ts`,
+      file: `build/index.d.ts`,
       format: "es",
     },
   }),


### PR DESCRIPTION
Fixes #17 

Package `lucid-cardano` only exports `esm` module but we exported both `esm` and `cjs` modules. When `cjs` module is being imported, it loads `lucid-cardano` and leads to the error. Only exporting `esm` module would be the way to go.

To test this:
- Create a next app: `npx create-next-app@latest`
- Install `@minswap/sdk` and import it into any **server** files.
- Run `npm run dev` and you will see the error.
- Now change the `package.json` config in the node_modules and run `npm run dev` again -> the error disappears.
- Add more code to test.